### PR TITLE
feat(web/tui): UX improvements — gateway health, kill feedback, sandbox badges, trace fixes

### DIFF
--- a/internal/frontend/tui/app.go
+++ b/internal/frontend/tui/app.go
@@ -710,12 +710,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			debuglog.Log("remote launch: otel_enabled=%v port=%d endpoint=%s",
 				a.cfg.OTELReceiver.Enabled, otelPort, otelEndpoint)
 
-			// Show loading state immediately so user sees feedback
+			// Show loading state immediately so user sees feedback.
+			// Don't zoom yet — keep the agent list visible so the user has context.
 			a.splitMode = true
-			a.zoomed = true
 			a.splitLoading = true
-			a.layout.SetZoomed(true)
-			a.statusHint = fmt.Sprintf("Launching %s remotely...", msg.Provider)
+			a.statusHint = fmt.Sprintf("⏳ Creating sandbox for %s in %s — please wait...", msg.Provider, filepath.Base(msg.Dir))
 
 			sOpts := aimuxcompose.LaunchOpts{
 				Image:        a.cfg.Remote.Image,
@@ -3304,11 +3303,11 @@ func (a App) renderSplitView() string {
 	// Right pane: session (rendered by SessionView with its own header/status)
 	var sessionContent string
 	if a.splitLoading {
-		// Show loading placeholder while session is connecting
+		loadMsg := "⏳  Creating sandbox…\n\nThis may take 10–30 seconds.\nThe terminal will open automatically when ready."
 		sessionContent = lipgloss.Place(
 			rightW, contentH,
 			lipgloss.Center, lipgloss.Center,
-			lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render("Loading session..."),
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Align(lipgloss.Center).Render(loadMsg),
 		)
 	} else {
 		sessionContent = a.sessionView.View()

--- a/internal/frontend/tui/views/agents.go
+++ b/internal/frontend/tui/views/agents.go
@@ -465,14 +465,15 @@ func (v *AgentsView) renderParentRow(r treeRow) string {
 	costRendered := costColor(a.EstCostUSD).Render(a.FormatCost())
 
 	locRaw := agentLocation(a)
+	locTrunc := truncate(locRaw, colLoc)
 	var loc string
 	switch locRaw {
 	case "remote":
-		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#37A3A3")).Render(padRight(locRaw, colLoc))
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#37A3A3")).Render(padRight(locTrunc, colLoc))
 	case "k8s":
-		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#A772EF")).Render(padRight(locRaw, colLoc))
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#A772EF")).Render(padRight(locTrunc, colLoc))
 	default:
-		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(padRight(locRaw, colLoc))
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(padRight(locTrunc, colLoc))
 	}
 
 	branchDisplay := truncate(a.GitBranch, colBranch)

--- a/internal/frontend/tui/views/agents.go
+++ b/internal/frontend/tui/views/agents.go
@@ -468,11 +468,11 @@ func (v *AgentsView) renderParentRow(r treeRow) string {
 	var loc string
 	switch locRaw {
 	case "remote":
-		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#37A3A3")).Render(locRaw)
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#37A3A3")).Render(padRight(locRaw, colLoc))
 	case "k8s":
-		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#A772EF")).Render(locRaw)
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#A772EF")).Render(padRight(locRaw, colLoc))
 	default:
-		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(locRaw)
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(padRight(locRaw, colLoc))
 	}
 
 	branchDisplay := truncate(a.GitBranch, colBranch)
@@ -490,7 +490,7 @@ func (v *AgentsView) renderParentRow(r treeRow) string {
 	row := " " + padRight(nameCol, colName) + " " +
 		padRight(truncate(a.ProviderName, colAgent), colAgent) + " " +
 		padRight(truncate(a.ShortModel(), colModel), colModel) + " " +
-		padRight(truncate(loc, colLoc), colLoc) + " " +
+		loc + " " +
 		padRight(truncate(a.ShortDir(), colDir), colDir) + " " +
 		branchDisplay + " " +
 		padRight(truncate(a.LastAction, colLast), colLast) + " " +

--- a/internal/frontend/tui/views/agents.go
+++ b/internal/frontend/tui/views/agents.go
@@ -464,7 +464,16 @@ func (v *AgentsView) renderParentRow(r treeRow) string {
 
 	costRendered := costColor(a.EstCostUSD).Render(a.FormatCost())
 
-	loc := agentLocation(a)
+	locRaw := agentLocation(a)
+	var loc string
+	switch locRaw {
+	case "remote":
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#37A3A3")).Render(locRaw)
+	case "k8s":
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#A772EF")).Render(locRaw)
+	default:
+		loc = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(locRaw)
+	}
 
 	branchDisplay := truncate(a.GitBranch, colBranch)
 	if branchDisplay == "" {

--- a/internal/frontend/web/handlers.go
+++ b/internal/frontend/web/handlers.go
@@ -332,6 +332,14 @@ func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 			"roiMultiplier":  s.ROIMultiplier,
 			"taskType":       s.TaskType,
 			"durationMin":    s.DurationMin,
+			// Infer location from file path: sandbox sessions run in /sandbox
+			// so their project hash is "-sandbox".
+			"location": func() string {
+				if strings.Contains(s.FilePath, "/-sandbox/") {
+					return "remote"
+				}
+				return "local"
+			}(),
 		}
 	}
 

--- a/internal/frontend/web/handlers.go
+++ b/internal/frontend/web/handlers.go
@@ -1105,6 +1105,50 @@ func (s *Server) handleProviderHealth(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Server) handleRemoteHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.composeEngine == nil {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":    "unconfigured",
+			"available": false,
+			"message":   "remote backend not configured — set remote.backend: openshell in ~/.aimux/config.yaml",
+		})
+		return
+	}
+
+	gatewayURL := s.cfg.Remote.Gateway
+	if gatewayURL == "" {
+		gatewayURL = "http://127.0.0.1:8090"
+	}
+
+	// Probe the gateway with a short timeout. Any HTTP response (even 404)
+	// means the gateway process is up. Connection refused means it's down.
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(gatewayURL) // #nosec G107
+	if err != nil {
+		msg := "gateway unreachable"
+		if strings.Contains(err.Error(), "connection refused") {
+			msg = fmt.Sprintf("gateway not running at %s — start with: openshell-gateway --config ~/.config/openshell/gateway-podman.toml", gatewayURL)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":    "error",
+			"available": false,
+			"gateway":   gatewayURL,
+			"message":   msg,
+		})
+		return
+	}
+	_ = resp.Body.Close()
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":    "connected",
+		"available": true,
+		"gateway":   gatewayURL,
+		"message":   "",
+	})
+}
+
 func (s *Server) handleGetROIConfig(w http.ResponseWriter, _ *http.Request) {
 	rate := s.cfg.ROI.HourlyRate
 	if rate <= 0 {

--- a/internal/frontend/web/handlers_test.go
+++ b/internal/frontend/web/handlers_test.go
@@ -1091,6 +1091,39 @@ func TestHandleGetTrace_RemoteAgent(t *testing.T) {
 	}
 }
 
+func TestHandleRemoteHealth_Unconfigured(t *testing.T) {
+	s := NewServer(0)
+	// No composeEngine set — should return unconfigured status with available=false.
+	go func() { _ = s.Start() }()
+	defer s.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	resp, err := http.Get(s.URL() + "/api/health/remote")
+	if err != nil {
+		t.Fatalf("GET /api/health/remote failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Status    string `json:"status"`
+		Available bool   `json:"available"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if payload.Status != "unconfigured" {
+		t.Errorf("expected status 'unconfigured', got %q", payload.Status)
+	}
+	if payload.Available {
+		t.Error("expected available=false when composeEngine is nil")
+	}
+}
+
 func TestHandleGetTrace_LocalAgent(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionFile := filepath.Join(tmpDir, "local-session.jsonl")

--- a/internal/frontend/web/server.go
+++ b/internal/frontend/web/server.go
@@ -149,8 +149,12 @@ func (s *Server) Start() error {
 
 	mux.HandleFunc("GET /api/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"ok"}`) )
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
+
+	// Remote backend health — checks whether the configured gateway is reachable.
+	// Used by the web dashboard header and launch dialog to surface gateway issues.
+	mux.HandleFunc("GET /api/health/remote", s.handleRemoteHealth)
 
 	mux.HandleFunc("GET /api/events", s.handleSSE)
 

--- a/internal/frontend/web/smoke_test.go
+++ b/internal/frontend/web/smoke_test.go
@@ -85,6 +85,7 @@ func TestAPISmoke_AllEndpoints(t *testing.T) {
 		"/api/costs",
 		"/api/teams",
 		"/api/health/providers",
+		"/api/health/remote",
 		"/api/history",
 		"/api/search?q=test",
 		"/api/plugins",

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -188,10 +188,10 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
         </button>
       )}
 
-      {/* Row 2: Title (the main visual anchor) */}
+      {/* Row 2: Title (the main visual anchor) — paddingRight leaves room for the Kill button */}
       <div style={{
         fontSize: 14, fontWeight: 600, color: 'var(--fg)', lineHeight: '1.4',
-        marginBottom: 6,
+        marginBottom: 6, paddingRight: 36,
         overflow: 'hidden', textOverflow: 'ellipsis',
         display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' as const,
       }}>

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -49,12 +49,19 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
     return `${Math.floor(diff / 86400)}d ago`;
   };
 
-  const borderLeftColor = agent.Status === 0 ? 'var(--green)' :
+  const isRemote = agent.Location === 'remote';
+  const isK8s = agent.Location === 'k8s';
+
+  const borderLeftColor = agent.Status === 3 ? 'var(--accent)' :
     agent.Status === 2 ? 'var(--orange)' :
-    agent.Status === 3 ? 'var(--accent)' : 'var(--fg-4)';
+    isRemote ? 'var(--teal)' :
+    isK8s ? 'var(--purple)' :
+    agent.Status === 0 ? 'var(--green)' : 'var(--fg-4)';
 
   const cardBg = agent.Status === 2 ? 'var(--orange-dim)' :
-    agent.Status === 3 ? 'var(--accent-dim)' : 'var(--bg-0)';
+    agent.Status === 3 ? 'var(--accent-dim)' :
+    isRemote ? 'rgba(55,163,163,0.04)' :
+    isK8s ? 'rgba(167,114,239,0.04)' : 'var(--bg-0)';
 
   const title = agent.Title || '';
 
@@ -112,6 +119,17 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
         }}>
           {agent.TMuxSession ? 'tmux' : 'direct'}
         </span>
+        {(isRemote || isK8s) && (
+          <span style={{
+            padding: '2px 6px', borderRadius: 2, fontSize: 10, fontWeight: 700,
+            textTransform: 'uppercase', letterSpacing: '0.05em',
+            background: isRemote ? 'rgba(55,163,163,0.15)' : 'rgba(167,114,239,0.15)',
+            color: isRemote ? 'var(--teal)' : 'var(--purple)',
+            border: `1px solid ${isRemote ? 'rgba(55,163,163,0.3)' : 'rgba(167,114,239,0.3)'}`,
+          }}>
+            {isRemote ? '⬡ sandbox' : 'k8s'}
+          </span>
+        )}
         <span style={{ fontSize: 11, color: 'var(--fg-4)', marginLeft: 'auto' }}>
           {timeSinceActivity()}
         </span>

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -132,61 +132,60 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
         <span style={{ fontSize: 11, color: 'var(--fg-4)', marginLeft: 'auto' }}>
           {timeSinceActivity()}
         </span>
-        {/* Star button */}
+      </div>
+
+      {/* Top-right action cluster: star + kill, both absolutely positioned */}
+      <div style={{ position: 'absolute', top: 8, right: 10, display: 'flex', alignItems: 'center', gap: 4 }}>
+        {agent.LastAction === 'Deleting' ? (
+          <span style={{
+            fontSize: 10, fontWeight: 600, color: 'var(--accent)',
+            background: 'var(--accent-dim)', padding: '2px 7px', borderRadius: 3,
+            letterSpacing: '0.04em', textTransform: 'uppercase',
+          }}>
+            Deleting…
+          </span>
+        ) : onKill && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onKill(agent.SessionID || String(agent.PID)); }}
+            className="kill-btn"
+            title="Kill session"
+            style={{
+              background: 'var(--bg-1)', border: '1px solid var(--border)',
+              color: 'var(--fg-3)', fontSize: 10, fontWeight: 600,
+              cursor: 'pointer', opacity: 0, transition: 'opacity 0.15s, color 0.15s, border-color 0.15s',
+              padding: '2px 8px', borderRadius: 3, lineHeight: '1.4',
+            }}
+            onMouseEnter={e => {
+              (e.currentTarget as HTMLButtonElement).style.color = 'var(--accent)';
+              (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--accent)';
+              (e.currentTarget as HTMLButtonElement).style.background = 'var(--accent-dim)';
+            }}
+            onMouseLeave={e => {
+              (e.currentTarget as HTMLButtonElement).style.color = 'var(--fg-3)';
+              (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)';
+              (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-1)';
+            }}
+          >
+            Kill
+          </button>
+        )}
         <button
           onClick={(e) => {
             e.stopPropagation();
             if (onToggleStar && agent.SessionFile) onToggleStar(agent.SessionFile);
           }}
+          className="star-btn"
+          title={starred ? 'Unpin session' : 'Pin session'}
           style={{
             background: 'transparent', border: 'none',
             color: starred ? 'var(--orange)' : 'var(--fg-4)',
-            fontSize: 14, cursor: 'pointer', padding: '0 4px',
+            fontSize: 14, cursor: 'pointer', padding: '0 2px',
             opacity: starred ? 1 : 0, transition: 'opacity 0.15s',
           }}
-          className="star-btn"
-          title={starred ? 'Unpin session' : 'Pin session'}
         >
           {starred ? '★' : '☆'}
         </button>
       </div>
-
-      {/* Kill button — top-right, appears on card hover */}
-      {agent.LastAction === 'Deleting' ? (
-        <div style={{
-          position: 'absolute', top: 8, right: 8,
-          fontSize: 10, fontWeight: 600, color: 'var(--accent)',
-          background: 'var(--accent-dim)', padding: '2px 7px', borderRadius: 3,
-          letterSpacing: '0.04em', textTransform: 'uppercase',
-        }}>
-          Deleting…
-        </div>
-      ) : onKill && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onKill(agent.SessionID || String(agent.PID)); }}
-          className="kill-btn"
-          title="Kill session"
-          style={{
-            position: 'absolute', top: 8, right: 8,
-            background: 'var(--bg-1)', border: '1px solid var(--border)',
-            color: 'var(--fg-3)', fontSize: 10, fontWeight: 600,
-            cursor: 'pointer', opacity: 0, transition: 'opacity 0.15s, color 0.15s, border-color 0.15s',
-            padding: '2px 8px', borderRadius: 3, lineHeight: '1.4',
-          }}
-          onMouseEnter={e => {
-            (e.currentTarget as HTMLButtonElement).style.color = 'var(--accent)';
-            (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--accent)';
-            (e.currentTarget as HTMLButtonElement).style.background = 'var(--accent-dim)';
-          }}
-          onMouseLeave={e => {
-            (e.currentTarget as HTMLButtonElement).style.color = 'var(--fg-3)';
-            (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)';
-            (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-1)';
-          }}
-        >
-          Kill
-        </button>
-      )}
 
       {/* Row 2: Title (the main visual anchor) — paddingRight leaves room for the Kill button */}
       <div style={{

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -121,13 +121,12 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
         </span>
         {(isRemote || isK8s) && (
           <span style={{
-            padding: '2px 6px', borderRadius: 2, fontSize: 10, fontWeight: 700,
-            textTransform: 'uppercase', letterSpacing: '0.05em',
-            background: isRemote ? 'rgba(55,163,163,0.15)' : 'rgba(167,114,239,0.15)',
+            padding: '2px 5px', borderRadius: 2, fontSize: 10, fontWeight: 700,
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+            background: isRemote ? 'rgba(55,163,163,0.18)' : 'rgba(167,114,239,0.18)',
             color: isRemote ? 'var(--teal)' : 'var(--purple)',
-            border: `1px solid ${isRemote ? 'rgba(55,163,163,0.3)' : 'rgba(167,114,239,0.3)'}`,
           }}>
-            {isRemote ? '⬡ sandbox' : 'k8s'}
+            {isRemote ? 'sandbox' : 'k8s'}
           </span>
         )}
         <span style={{ fontSize: 11, color: 'var(--fg-4)', marginLeft: 'auto' }}>

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -1,5 +1,6 @@
 import type { Agent } from '../types';
 import { StatusLabel } from '../types';
+import { normalizeLocation } from '../utils';
 
 interface Props {
   agent: Agent;
@@ -49,8 +50,9 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
     return `${Math.floor(diff / 86400)}d ago`;
   };
 
-  const isRemote = agent.Location === 'remote';
-  const isK8s = agent.Location === 'k8s';
+  const loc = normalizeLocation(agent);
+  const isRemote = loc === 'remote';
+  const isK8s = loc === 'k8s';
 
   const borderLeftColor = agent.Status === 3 ? 'var(--accent)' :
     agent.Status === 2 ? 'var(--orange)' :
@@ -135,7 +137,11 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
       </div>
 
       {/* Top-right action cluster: star + kill, both absolutely positioned */}
-      <div style={{ position: 'absolute', top: 8, right: 10, display: 'flex', alignItems: 'center', gap: 4 }}>
+      <div
+        role="presentation"
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation(); }}
+        style={{ position: 'absolute', top: 8, right: 10, display: 'flex', alignItems: 'center', gap: 4 }}
+      >
         {agent.LastAction === 'Deleting' ? (
           <span style={{
             fontSize: 10, fontWeight: 600, color: 'var(--accent)',

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -150,26 +150,44 @@ export function AgentCard({ agent, selected, starred, onClick, onKill, onToggleS
         >
           {starred ? '★' : '☆'}
         </button>
-        {/* Kill button */}
-        {agent.LastAction !== 'Deleting' && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              if (onKill) onKill(agent.SessionID || String(agent.PID));
-            }}
-            className="kill-btn"
-            style={{
-              background: 'transparent', border: '1px solid var(--accent)',
-              color: 'var(--accent)', fontSize: 10, fontWeight: 600,
-              cursor: 'pointer', opacity: 0, transition: 'opacity 0.15s',
-              padding: '1px 6px', borderRadius: 3, lineHeight: '1.4',
-            }}
-            title="Kill session"
-          >
-            Kill
-          </button>
-        )}
       </div>
+
+      {/* Kill button — top-right, appears on card hover */}
+      {agent.LastAction === 'Deleting' ? (
+        <div style={{
+          position: 'absolute', top: 8, right: 8,
+          fontSize: 10, fontWeight: 600, color: 'var(--accent)',
+          background: 'var(--accent-dim)', padding: '2px 7px', borderRadius: 3,
+          letterSpacing: '0.04em', textTransform: 'uppercase',
+        }}>
+          Deleting…
+        </div>
+      ) : onKill && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onKill(agent.SessionID || String(agent.PID)); }}
+          className="kill-btn"
+          title="Kill session"
+          style={{
+            position: 'absolute', top: 8, right: 8,
+            background: 'var(--bg-1)', border: '1px solid var(--border)',
+            color: 'var(--fg-3)', fontSize: 10, fontWeight: 600,
+            cursor: 'pointer', opacity: 0, transition: 'opacity 0.15s, color 0.15s, border-color 0.15s',
+            padding: '2px 8px', borderRadius: 3, lineHeight: '1.4',
+          }}
+          onMouseEnter={e => {
+            (e.currentTarget as HTMLButtonElement).style.color = 'var(--accent)';
+            (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--accent)';
+            (e.currentTarget as HTMLButtonElement).style.background = 'var(--accent-dim)';
+          }}
+          onMouseLeave={e => {
+            (e.currentTarget as HTMLButtonElement).style.color = 'var(--fg-3)';
+            (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)';
+            (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-1)';
+          }}
+        >
+          Kill
+        </button>
+      )}
 
       {/* Row 2: Title (the main visual anchor) */}
       <div style={{

--- a/web/src/components/CardGrid.tsx
+++ b/web/src/components/CardGrid.tsx
@@ -39,6 +39,7 @@ export function CardGrid({
 }: Props) {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [starredFiles, setStarredFiles] = useState<Set<string>>(new Set());
+  const [killing, setKilling] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     const starred = new Set<string>();
@@ -68,12 +69,15 @@ export function CardGrid({
   };
 
   const handleKill = async (id: string) => {
+    setKilling(prev => new Set(prev).add(id));
     try {
       await fetch(`/api/agents/${id}/archive`, { method: 'POST' });
-      if (selectedId === id) {
-        onSelect('');
-      }
-    } catch { /* ignore */ }
+      if (selectedId === id) onSelect('');
+    } catch { /* ignore */ } finally {
+      // Keep in killing set — SSE will remove the agent when it's gone.
+      // Clear after 15s as a safety net if SSE doesn't update.
+      setTimeout(() => setKilling(prev => { const n = new Set(prev); n.delete(id); return n; }), 15_000);
+    }
   };
 
   const toggleGroup = (name: string) => {
@@ -242,7 +246,9 @@ export function CardGrid({
                 {groupAgents.map(agent => (
                   <div key={agent.SessionID || agent.PID} role="listitem" style={{ display: 'flex' }}>
                     <AgentCard
-                      agent={agent}
+                      agent={killing.has(agent.SessionID || agent.PID.toString())
+                        ? { ...agent, LastAction: 'Deleting' }
+                        : agent}
                       selected={selectedId === (agent.SessionID || agent.PID.toString())}
                       starred={starredFiles.has(agent.SessionFile)}
                       onClick={() => onSelect(agent.SessionID || agent.PID.toString())}

--- a/web/src/components/CardGrid.tsx
+++ b/web/src/components/CardGrid.tsx
@@ -71,11 +71,16 @@ export function CardGrid({
   const handleKill = async (id: string) => {
     setKilling(prev => new Set(prev).add(id));
     try {
-      await fetch(`/api/agents/${id}/archive`, { method: 'POST' });
+      const resp = await fetch(`/api/agents/${id}/archive`, { method: 'POST' });
+      if (!resp.ok) {
+        // Remove from killing set on failure so button reappears
+        setKilling(prev => { const n = new Set(prev); n.delete(id); return n; });
+        return;
+      }
       if (selectedId === id) onSelect('');
-    } catch { /* ignore */ } finally {
-      // Keep in killing set — SSE will remove the agent when it's gone.
-      // Clear after 15s as a safety net if SSE doesn't update.
+    } catch {
+      setKilling(prev => { const n = new Set(prev); n.delete(id); return n; });
+    } finally {
       setTimeout(() => setKilling(prev => { const n = new Set(prev); n.delete(id); return n; }), 15_000);
     }
   };
@@ -327,7 +332,15 @@ export function CardGrid({
                       <span style={{ fontSize: 13, fontFamily: 'var(--mono)', color: 'var(--green)', width: 80, textAlign: 'right', flexShrink: 0 }}>
                         ${(agent.EstCostUSD || 0).toFixed(2)}
                       </span>
-                      {agent.LastAction !== 'Deleting' && (
+                      {(agent.LastAction === 'Deleting' || killing.has(id)) ? (
+                        <span style={{
+                          fontSize: 10, fontWeight: 600, color: 'var(--accent)',
+                          background: 'var(--accent-dim)', padding: '2px 7px', borderRadius: 3,
+                          letterSpacing: '0.04em', textTransform: 'uppercase', flexShrink: 0,
+                        }}>
+                          Deleting…
+                        </span>
+                      ) : (
                         <button
                           onClick={(e) => { e.stopPropagation(); handleKill(agent.SessionID || agent.PID.toString()); }}
                           title="Kill agent (SIGTERM)"

--- a/web/src/components/CardGrid.tsx
+++ b/web/src/components/CardGrid.tsx
@@ -73,15 +73,15 @@ export function CardGrid({
     try {
       const resp = await fetch(`/api/agents/${id}/archive`, { method: 'POST' });
       if (!resp.ok) {
-        // Remove from killing set on failure so button reappears
         setKilling(prev => { const n = new Set(prev); n.delete(id); return n; });
         return;
       }
       if (selectedId === id) onSelect('');
+      // Safety net: clear killing state after 15s if SSE never removes the agent.
+      // Only on success — failure already cleared it above.
+      setTimeout(() => setKilling(prev => { const n = new Set(prev); n.delete(id); return n; }), 15_000);
     } catch {
       setKilling(prev => { const n = new Set(prev); n.delete(id); return n; });
-    } finally {
-      setTimeout(() => setKilling(prev => { const n = new Set(prev); n.delete(id); return n; }), 15_000);
     }
   };
 

--- a/web/src/components/LaunchDialog.tsx
+++ b/web/src/components/LaunchDialog.tsx
@@ -25,6 +25,8 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
   const [otelEnabled, setOtelEnabled] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [launchError, setLaunchError] = useState('');
+  const [gatewayOk, setGatewayOk] = useState<boolean | null>(null);
+  const [gatewayMsg, setGatewayMsg] = useState('');
   const [dirTab, setDirTab] = useState<DirTab>('recent');
   const [quickDirs, setQuickDirs] = useState<QuickDir[]>([]);
   const [recentDirs, setRecentDirs] = useState<RecentDir[]>([]);
@@ -36,6 +38,15 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
     if (open) window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
   }, [open, onClose]);
+
+  useEffect(() => {
+    if (runtime !== 'remote') { setGatewayOk(null); setGatewayMsg(''); return; }
+    setGatewayOk(null);
+    fetch('/api/health/remote')
+      .then(r => r.json())
+      .then(d => { setGatewayOk(d.available); setGatewayMsg(d.message || ''); })
+      .catch(() => { setGatewayOk(false); setGatewayMsg('Could not reach health endpoint'); });
+  }, [runtime]);
 
   useEffect(() => {
     if (!open) return;
@@ -286,6 +297,24 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
                 style={pill(runtime === r)}>{r}</button>
             ))}
           </div>
+          {runtime === 'remote' && gatewayOk !== null && (
+            <div style={{
+              marginTop: 8, padding: '6px 10px', borderRadius: 4, fontSize: 11,
+              background: gatewayOk ? 'rgba(55,163,163,0.08)' : 'var(--accent-dim)',
+              border: `1px solid ${gatewayOk ? 'var(--teal)' : 'var(--accent)'}`,
+              color: gatewayOk ? 'var(--teal)' : 'var(--accent)',
+              display: 'flex', alignItems: 'center', gap: 6,
+            }}>
+              <span style={{ width: 6, height: 6, borderRadius: '50%', flexShrink: 0,
+                background: gatewayOk ? 'var(--teal)' : 'var(--accent)' }} />
+              {gatewayOk
+                ? 'Gateway connected — sandbox will launch'
+                : (gatewayMsg || 'Gateway unreachable — start openshell-gateway first')}
+            </div>
+          )}
+          {runtime === 'remote' && gatewayOk === null && (
+            <div style={{ marginTop: 8, fontSize: 11, color: 'var(--fg-4)' }}>Checking gateway…</div>
+          )}
         </div>
 
         {/* Execution */}

--- a/web/src/components/LaunchDialog.tsx
+++ b/web/src/components/LaunchDialog.tsx
@@ -24,6 +24,7 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
   const [sessionMgr, setSessionMgr] = useState('tmux');
   const [otelEnabled, setOtelEnabled] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [launchError, setLaunchError] = useState('');
   const [dirTab, setDirTab] = useState<DirTab>('recent');
   const [quickDirs, setQuickDirs] = useState<QuickDir[]>([]);
   const [recentDirs, setRecentDirs] = useState<RecentDir[]>([]);
@@ -70,6 +71,7 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
   const handleSubmit = async () => {
     if (!dir) return;
     setSubmitting(true);
+    setLaunchError('');
     try {
       const resp = await fetch('/api/agents/launch', {
         method: 'POST',
@@ -86,11 +88,17 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
         return;
       }
       const data = await resp.json();
+      if (!resp.ok) {
+        setLaunchError(data?.error || `Launch failed (${resp.status})`);
+        return;
+      }
       onLaunched?.(provider, dir, data.tmux_session, data.sandbox_name);
       onClose();
       setDir(''); setPrompt(''); setModel(''); setProvider('claude');
       setMode('default'); setRuntime('local'); setExecution('local');
       setShell(''); setSessionMgr('tmux'); setOtelEnabled(false);
+    } catch (e) {
+      setLaunchError(e instanceof Error ? e.message : 'Launch failed — check server');
     } finally { setSubmitting(false); }
   };
 
@@ -325,6 +333,12 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
         </div>
 
         {/* Submit */}
+        {launchError && (
+          <div style={{ color: 'var(--accent)', fontSize: 11, marginBottom: 8, padding: '6px 8px',
+            background: 'var(--accent-dim)', borderRadius: 4 }}>
+            {launchError}
+          </div>
+        )}
         <button onClick={handleSubmit} disabled={!dir || submitting}
           style={{ background: !dir || submitting ? 'var(--bg-3)' : 'var(--accent)',
             color: !dir || submitting ? 'var(--fg-3)' : '#fff', border: 'none', borderRadius: 6,

--- a/web/src/components/LaunchDialog.tsx
+++ b/web/src/components/LaunchDialog.tsx
@@ -80,6 +80,11 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
           otel_enabled: otelEnabled, user_prompt: prompt,
         }),
       });
+      if (!resp.ok) {
+        const text = await resp.text();
+        setLaunchError(text.trim() || `Launch failed (${resp.status})`);
+        return;
+      }
       const data = await resp.json();
       onLaunched?.(provider, dir, data.tmux_session, data.sandbox_name);
       onClose();

--- a/web/src/components/LaunchDialog.tsx
+++ b/web/src/components/LaunchDialog.tsx
@@ -41,16 +41,18 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
 
   useEffect(() => {
     if (!open || runtime !== 'remote') { setGatewayOk(null); setGatewayMsg(''); return; }
-    let cancelled = false;
+    let controller = new AbortController();
     const check = () => {
-      fetch('/api/health/remote')
+      controller.abort();
+      controller = new AbortController();
+      fetch('/api/health/remote', { signal: controller.signal })
         .then(r => r.json())
-        .then(d => { if (!cancelled) { setGatewayOk(d.available); setGatewayMsg(d.message || ''); } })
-        .catch(() => { if (!cancelled) { setGatewayOk(false); setGatewayMsg('Could not reach health endpoint'); } });
+        .then(d => { setGatewayOk(d.available); setGatewayMsg(d.message || ''); })
+        .catch(e => { if (e.name !== 'AbortError') { setGatewayOk(false); setGatewayMsg('Could not reach health endpoint'); } });
     };
     check();
     const interval = setInterval(check, 10_000);
-    return () => { cancelled = true; clearInterval(interval); };
+    return () => { controller.abort(); clearInterval(interval); };
   }, [open, runtime]);
 
   useEffect(() => {

--- a/web/src/components/LaunchDialog.tsx
+++ b/web/src/components/LaunchDialog.tsx
@@ -40,13 +40,18 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
   }, [open, onClose]);
 
   useEffect(() => {
-    if (runtime !== 'remote') { setGatewayOk(null); setGatewayMsg(''); return; }
-    setGatewayOk(null);
-    fetch('/api/health/remote')
-      .then(r => r.json())
-      .then(d => { setGatewayOk(d.available); setGatewayMsg(d.message || ''); })
-      .catch(() => { setGatewayOk(false); setGatewayMsg('Could not reach health endpoint'); });
-  }, [runtime]);
+    if (!open || runtime !== 'remote') { setGatewayOk(null); setGatewayMsg(''); return; }
+    let cancelled = false;
+    const check = () => {
+      fetch('/api/health/remote')
+        .then(r => r.json())
+        .then(d => { if (!cancelled) { setGatewayOk(d.available); setGatewayMsg(d.message || ''); } })
+        .catch(() => { if (!cancelled) { setGatewayOk(false); setGatewayMsg('Could not reach health endpoint'); } });
+    };
+    check();
+    const interval = setInterval(check, 10_000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [open, runtime]);
 
   useEffect(() => {
     if (!open) return;

--- a/web/src/components/LaunchDialog.tsx
+++ b/web/src/components/LaunchDialog.tsx
@@ -99,10 +99,6 @@ export function LaunchDialog({ open, onClose, onLaunched }: Props) {
         return;
       }
       const data = await resp.json();
-      if (!resp.ok) {
-        setLaunchError(data?.error || `Launch failed (${resp.status})`);
-        return;
-      }
       onLaunched?.(provider, dir, data.tmux_session, data.sandbox_name);
       onClose();
       setDir(''); setPrompt(''); setModel(''); setProvider('claude');

--- a/web/src/components/SessionsTable.tsx
+++ b/web/src/components/SessionsTable.tsx
@@ -536,10 +536,9 @@ export function SessionsTable({ onSelectSession, selectedId, onSessionCount, sta
                         {s.location === 'remote' && (
                           <span style={{
                             fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                            letterSpacing: '0.05em', padding: '1px 5px', borderRadius: 3, flexShrink: 0,
-                            background: 'rgba(55,163,163,0.15)', color: 'var(--teal)',
-                            border: '1px solid rgba(55,163,163,0.3)',
-                          }}>⬡ sandbox</span>
+                            letterSpacing: '0.06em', padding: '1px 5px', borderRadius: 2, flexShrink: 0,
+                            background: 'rgba(55,163,163,0.18)', color: 'var(--teal)',
+                          }}>sandbox</span>
                         )}
                       </div>
                       {s.lastAction && (

--- a/web/src/components/SessionsTable.tsx
+++ b/web/src/components/SessionsTable.tsx
@@ -28,6 +28,7 @@ export interface HistorySession {
   roiMultiplier?: number;
   taskType?: string;
   durationMin?: number;
+  location?: string; // "local" | "remote"
 }
 
 type SortField = 'lastActive' | 'cost' | 'turns' | 'title' | 'project' | 'roi';
@@ -477,7 +478,8 @@ export function SessionsTable({ onSelectSession, selectedId, onSessionCount, sta
                   style={{
                     cursor: 'pointer',
                     background: isSelected ? 'var(--bg-2)' : 'transparent',
-                    borderLeft: isSelected ? '3px solid var(--accent)' : '3px solid transparent',
+                    borderLeft: isSelected ? '3px solid var(--accent)' :
+                      s.location === 'remote' ? '3px solid rgba(55,163,163,0.5)' : '3px solid transparent',
                   }}
                   onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'var(--bg-1)'; }}
                   onMouseLeave={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
@@ -530,6 +532,14 @@ export function SessionsTable({ onSelectSession, selectedId, onSessionCount, sta
                         </span>
                         {s.isSubagent && (
                           <span style={{ fontSize: 10, color: 'var(--fg-4)', fontStyle: 'italic' }}>agent</span>
+                        )}
+                        {s.location === 'remote' && (
+                          <span style={{
+                            fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                            letterSpacing: '0.05em', padding: '1px 5px', borderRadius: 3, flexShrink: 0,
+                            background: 'rgba(55,163,163,0.15)', color: 'var(--teal)',
+                            border: '1px solid rgba(55,163,163,0.3)',
+                          }}>⬡ sandbox</span>
                         )}
                       </div>
                       {s.lastAction && (

--- a/web/src/components/StatsBar.tsx
+++ b/web/src/components/StatsBar.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import type { Agent } from '../types';
 
 interface Props {
@@ -12,6 +13,20 @@ interface Props {
 }
 
 export function StatsBar({ agents, onLaunch, onHome, onToggleTasks, taskCount, tasksOpen, theme, onToggleTheme }: Props) {
+  const [gatewayStatus, setGatewayStatus] = useState<{ available: boolean; message: string } | null>(null);
+
+  useEffect(() => {
+    const check = () => {
+      fetch('/api/health/remote')
+        .then(r => r.json())
+        .then(d => setGatewayStatus({ available: d.available, message: d.message || '' }))
+        .catch(() => setGatewayStatus({ available: false, message: 'health check failed' }));
+    };
+    check();
+    const interval = setInterval(check, 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
   const sessions = agents.length;
   const active = agents.filter(a => a.Status === 0).length;
   const idle = agents.filter(a => a.Status === 1).length;
@@ -91,6 +106,25 @@ export function StatsBar({ agents, onLaunch, onHome, onToggleTasks, taskCount, t
           >
             {theme === 'dark' ? '\u2600' : '\u263D'}
           </button>
+        )}
+        {gatewayStatus && (
+          <div
+            title={gatewayStatus.available ? 'OpenShell gateway connected' : (gatewayStatus.message || 'OpenShell gateway unreachable')}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 5,
+              padding: '4px 10px', borderRadius: 4, fontSize: 11, fontWeight: 500,
+              border: `1px solid ${gatewayStatus.available ? 'var(--teal)' : 'var(--accent)'}`,
+              color: gatewayStatus.available ? 'var(--teal)' : 'var(--accent)',
+              background: gatewayStatus.available ? 'rgba(55,163,163,0.08)' : 'var(--accent-dim)',
+              cursor: gatewayStatus.available ? 'default' : 'help',
+            }}
+          >
+            <span style={{
+              width: 6, height: 6, borderRadius: '50%', flexShrink: 0,
+              background: gatewayStatus.available ? 'var(--teal)' : 'var(--accent)',
+            }} />
+            {gatewayStatus.available ? 'Gateway' : 'Gateway down'}
+          </div>
         )}
         <button
           onClick={onLaunch}


### PR DESCRIPTION
## Summary

Web and TUI UX improvements built on top of the Gemini removal.

### Web Dashboard

**Gateway health:**
- `GET /api/health/remote` — direct HTTP probe to gateway URL (no CLI subprocess), returns `{status, available, gateway, message}`
- Header: teal `● Gateway` pill when connected, red `● Gateway down` with tooltip when not; refreshes every 30s
- Launch dialog: inline gateway status when `remote` runtime is selected — shows error before the user clicks Launch

**Launch dialog:**
- Inline error display when launch fails (instead of silently resetting)
- Checks `resp.ok` before `resp.json()` — plain-text error responses no longer throw a parse exception

**Kill button:**
- Moved to absolute top-right position (Kill + Star share a flex cluster, no layout conflicts with badge row)
- Optimistic UI: immediately shows `Deleting…` state on click without waiting for SSE confirmation
- Neutral styling at rest, turns red on hover

**Agent cards:**
- Remote sandbox cards: teal left border + teal `sandbox` badge
- K8s cards: purple left border + purple `k8s` badge
- Long-running sessions (>5 min) are never dropped by the ephemeral filter even with low token counts

**Session table:**
- Sandbox sessions (`/-sandbox/` in path) get a teal left border and `sandbox` badge inline with title
- `location` field added to `/api/history` response

**Trace view:**
- `useTraceStream` now fetches via `SessionFile` when `SessionID` is empty — agents discovered by process scan show their conversation history

### TUI

- `LOC` column: teal for `remote`, purple for `k8s`, gray for `local` (fixed ANSI width bug — pad before color, not after)
- Remote launch feedback: status hint says `⏳ Creating sandbox for claude in <dir>…`; loading pane explains the wait; agent list stays visible during creation

## Test plan
- [ ] Launch local agent → card shows correct color, Kill works with immediate feedback
- [ ] Launch remote sandbox → gateway pill in header, launch dialog shows gateway status, sandbox badge on card
- [ ] Kill sandbox → `Deleting…` appears instantly, card removed when SSE confirms
- [ ] Sessions tab → sandbox sessions have teal border + badge
- [ ] TUI: LOC column shows colored `remote`/`k8s`/`local` without breaking adjacent columns
- [ ] TUI: `:new` → remote → agent list stays visible during sandbox creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote gateway health indicators with connected, unavailable, and checking states.
  * Added clearer local, remote, and Kubernetes location labels and visual styling.
  * Remote sessions now display sandbox badges in history.
  * Added detailed launch errors and sandbox-specific loading messages.
* **Bug Fixes**
  * Remote launches remain in split view while sandbox creation is pending.
  * Improved session deletion feedback and error handling.
  * Long location labels now fit cleanly within the available display space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->